### PR TITLE
fix(wasm_hover): remove json serialization

### DIFF
--- a/packages/benchmark-wasm/benchmarks/hover.bench.ts
+++ b/packages/benchmark-wasm/benchmarks/hover.bench.ts
@@ -1,12 +1,11 @@
-import { get_hover } from "../../csslsrs/dist/generated/csslsrs";
-import { getCSSLanguageService } from "vscode-css-languageservice";
-import { TextDocument } from "vscode-languageserver-textdocument";
-import cssCustomData from "../../../crates/csslsrs/data/css-schema.json";
-import { bench, describe } from "vitest";
+import { get_hover } from "../../csslsrs/dist/generated/csslsrs"
+import { getCSSLanguageService } from "vscode-css-languageservice"
+import { TextDocument } from "vscode-languageserver-textdocument"
+import { bench, describe } from "vitest"
 
 describe("Hover", async () => {
-	const vscodeLanguageService = getCSSLanguageService();
-	const content = `
+  const vscodeLanguageService = getCSSLanguageService()
+  const content = `
 body {
   background-color: #fff;
 }
@@ -22,26 +21,26 @@ h1.foo {
 h1 > span {
   color: linear-gradient(to right, red, #fff);
 }
-`;
+`
 
-	const textDocument = TextDocument.create(
-		"file:///test.css",
-		"css",
-		0,
-		content
-	);
+  const textDocument = TextDocument.create(
+    "file:///test.css",
+    "css",
+    0,
+    content
+  )
 
-	bench("CSSLSRS(WASM) - Hover", async () => {
-		await get_hover(textDocument, { line: 4, character: 3 }, cssCustomData);
-	});
-	if (!process.env.CODSPEED) {
-		bench("vscode-css-languageservice - Hover", () => {
-			const stylesheet = vscodeLanguageService.parseStylesheet(textDocument);
-			vscodeLanguageService.doHover(
-				textDocument,
-				{ line: 4, character: 3 },
-				stylesheet
-			);
-		});
-	}
-});
+  bench("CSSLSRS(WASM) - Hover", async () => {
+    await get_hover(textDocument, { line: 4, character: 3 })
+  })
+  if (!process.env.CODSPEED) {
+    bench("vscode-css-languageservice - Hover", () => {
+      const stylesheet = vscodeLanguageService.parseStylesheet(textDocument)
+      vscodeLanguageService.doHover(
+        textDocument,
+        { line: 4, character: 3 },
+        stylesheet
+      )
+    })
+  }
+})


### PR DESCRIPTION
For `get_hover` in WASM : Embedding JSON data at compile time, modifying the function signature, and updating the benchmark to reflect these changes.

## How is it tested?

Through benchmarks.

## How is it documented?

A comment was added to the code, and I'll create an issue.