### PR TITLE
feat(language_service): Allow users to add custom css custom data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,18 +324,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.22"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69371e34337c4c984bbe322360c2547210bf632eb2814bbe78a6e87a2935bd2b"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.22"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e24c1b4099818523236a8ca881d2b45db98dadfb4625cf6608c12069fcbbde1"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "codspeed"
@@ -627,9 +627,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1248,9 +1248,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1259,13 +1259,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -1274,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1284,9 +1283,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1297,15 +1296,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "web-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/csslsrs/benches/features/color.rs
+++ b/crates/csslsrs/benches/features/color.rs
@@ -13,6 +13,8 @@ fn get_colors_benchmark(c: &mut Criterion) {
         text: "body { color: red; }".to_string(),
     };
 
+    ls.store.upsert_document(document.clone());
+
     c.bench_function("get_document_colors", |b| {
         b.iter(|| ls.get_document_colors(black_box(document.clone())))
     });
@@ -27,6 +29,8 @@ fn get_color_presentations_benchmark(c: &mut Criterion) {
         version: 0,
         text: "body { color: red; }".to_string(),
     };
+
+    ls.store.upsert_document(document.clone());
 
     let colors = ls.get_document_colors(document);
     let color = colors.first().unwrap();

--- a/crates/csslsrs/benches/features/folding.rs
+++ b/crates/csslsrs/benches/features/folding.rs
@@ -48,6 +48,8 @@ fn get_folding_ranges_benchmark(c: &mut Criterion) {
         text: TEST_CASE.to_string(),
     };
 
+    ls.store.upsert_document(document.clone());
+
     c.bench_function("get_folding_ranges", |b| {
         b.iter(|| ls.get_folding_ranges(black_box(document.clone())))
     });

--- a/crates/csslsrs/benches/features/hover.rs
+++ b/crates/csslsrs/benches/features/hover.rs
@@ -13,14 +13,10 @@ fn get_hover_benchmark(c: &mut Criterion) {
         text: "body { color: red; }".to_string(),
     };
 
+    ls.store.upsert_document(document.clone());
+
     c.bench_function("get_hover", |b| {
-        b.iter(|| {
-            ls.get_hover(
-                black_box(document.clone()),
-                lsp_types::Position::new(0, 8),
-                ls.css_data,
-            )
-        })
+        b.iter(|| ls.get_hover(black_box(document.clone()), lsp_types::Position::new(0, 8)))
     });
 }
 

--- a/crates/csslsrs/src/css_data.rs
+++ b/crates/csslsrs/src/css_data.rs
@@ -1,4 +1,20 @@
 use serde::Deserialize;
+use std::sync::LazyLock;
+
+pub(crate) static BASE_CSS_DATA: LazyLock<CssCustomData> = LazyLock::new(|| {
+    serde_json::from_str(include_str!("../data/css-schema.json"))
+        .expect("Failed to parse css-schema.json")
+});
+
+// This is used when the user sets `include_base_css_custom_data` to false in the LanguageServiceOptions.
+pub(crate) static EMPTY_CSS_DATA: CssCustomData = CssCustomData {
+    css: CssSection {
+        at_directives: AtDirectives { entry: vec![] },
+        pseudo_classes: PseudoClasses { entry: vec![] },
+        pseudo_elements: PseudoElements { entry: vec![] },
+        properties: Properties { entry: vec![] },
+    },
+};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/csslsrs/src/features/colors.rs
+++ b/crates/csslsrs/src/features/colors.rs
@@ -129,14 +129,19 @@ fn compute_color_presentations(color: ColorInformation, range: Range) -> Vec<Col
 }
 
 impl LanguageService {
-    pub fn get_document_colors(&mut self, document: TextDocumentItem) -> Vec<ColorInformation> {
-        let store_entry = self.store.get_or_update_document(document);
+    pub fn get_document_colors(&self, document: TextDocumentItem) -> Vec<ColorInformation> {
+        let store_entry = self.store.get(&document.uri);
 
-        find_document_colors(
-            &store_entry.css_tree,
-            &store_entry.line_index,
-            self.encoding,
-        )
+        match store_entry {
+            Some(store_entry) => find_document_colors(
+                &store_entry.css_tree,
+                &store_entry.line_index,
+                self.options.encoding,
+            ),
+            None => {
+                vec![]
+            }
+        }
     }
 
     pub fn get_color_presentations(

--- a/crates/csslsrs/src/features/folding.rs
+++ b/crates/csslsrs/src/features/folding.rs
@@ -166,9 +166,15 @@ fn compute_folding_ranges(
 impl LanguageService {
     /// Get the folding ranges for the given CSS source code. It supports CSS blocks enclosed in
     /// braces, multi-line comments, and regions marked with `#region` and `#endregion` comments.
-    pub fn get_folding_ranges(&mut self, document: TextDocumentItem) -> Vec<FoldingRange> {
-        let store_document = self.store.get_or_update_document(document);
-        compute_folding_ranges(&store_document.document, &store_document.line_index)
+    pub fn get_folding_ranges(&self, document: TextDocumentItem) -> Vec<FoldingRange> {
+        let store_document = self.store.get(&document.uri);
+
+        match store_document {
+            Some(store_document) => {
+                compute_folding_ranges(&store_document.document, &store_document.line_index)
+            }
+            None => Vec::new(),
+        }
     }
 }
 
@@ -184,7 +190,7 @@ mod wasm_bindings {
 /**
  * Get the folding ranges for the given CSS source code. It supports CSS blocks enclosed in
  * braces, multi-line comments, and regions marked with `#region` and `#endregion` comments.
- * 
+ *
  * @param source The CSS source code as a `TextDocument`.
  * @returns A list of `FoldingRange` objects indicating the foldable regions in the CSS code.
  */

--- a/crates/csslsrs/src/features/hover.rs
+++ b/crates/csslsrs/src/features/hover.rs
@@ -14,7 +14,7 @@ fn extract_hover_information(
     position: Position,
     line_index: &LineIndex,
     encoding: PositionEncoding,
-    css_data: &CssCustomData,
+    css_data: &Vec<&CssCustomData>,
 ) -> Option<Hover> {
     let offset = offset(line_index, position, encoding).ok()?;
     let token = node.token_at_offset(offset).right_biased()?;
@@ -76,44 +76,54 @@ fn extract_hover_information(
 fn get_css_hover_content(
     kind: CssSyntaxKind,
     name: &str,
-    css_data: &CssCustomData,
+    css_data: &Vec<&CssCustomData>,
 ) -> Option<String> {
     match kind {
-        CssSyntaxKind::CSS_IDENTIFIER => css_data
-            .css
-            .properties
-            .entry
-            .iter()
-            .find(|prop| prop.attributes.name == name)
-            .map(|property| {
-                format_css_entry(
-                    &property.attributes.name,
-                    property.desc.as_deref(),
-                    property.attributes.syntax.as_deref(),
-                    None,
-                    property.attributes.browsers.as_deref(),
-                    property.attributes.ref_.as_deref(),
-                    property.attributes.restriction.as_deref(),
-                )
-            }),
+        CssSyntaxKind::CSS_IDENTIFIER => {
+            for data in css_data {
+                if let Some(property) = data
+                    .css
+                    .properties
+                    .entry
+                    .iter()
+                    .find(|prop| prop.attributes.name == name)
+                {
+                    return Some(format_css_entry(
+                        &property.attributes.name,
+                        property.desc.as_deref(),
+                        property.attributes.syntax.as_deref(),
+                        None,
+                        property.attributes.browsers.as_deref(),
+                        property.attributes.ref_.as_deref(),
+                        property.attributes.restriction.as_deref(),
+                    ));
+                }
+            }
+            None
+        }
         // Handle at-rules like @media, @supports, etc.
-        CssSyntaxKind::CSS_AT_RULE => css_data
-            .css
-            .at_directives
-            .entry
-            .iter()
-            .find(|ad| ad.attributes.name == name)
-            .map(|at_directive| {
-                format_css_entry(
-                    &at_directive.attributes.name,
-                    at_directive.desc.as_deref(),
-                    at_directive.attributes.syntax.as_deref(),
-                    None,
-                    at_directive.attributes.browsers.as_deref(),
-                    at_directive.attributes.ref_.as_deref(),
-                    None,
-                )
-            }),
+        CssSyntaxKind::CSS_AT_RULE => {
+            for data in css_data {
+                if let Some(at_directive) = data
+                    .css
+                    .at_directives
+                    .entry
+                    .iter()
+                    .find(|ad| ad.attributes.name == name)
+                {
+                    return Some(format_css_entry(
+                        &at_directive.attributes.name,
+                        at_directive.desc.as_deref(),
+                        at_directive.attributes.syntax.as_deref(),
+                        None,
+                        at_directive.attributes.browsers.as_deref(),
+                        at_directive.attributes.ref_.as_deref(),
+                        None,
+                    ));
+                }
+            }
+            None
+        }
         CssSyntaxKind::CSS_SELECTOR_LIST
         | CssSyntaxKind::CSS_COMPLEX_SELECTOR
         | CssSyntaxKind::CSS_COMPOUND_SELECTOR => Some(format_css_entry(
@@ -310,21 +320,20 @@ fn is_identifier_char(c: char) -> bool {
 
 impl LanguageService {
     /// Gets the hover information for the given CSS document and position.
-    pub fn get_hover(
-        &mut self,
-        document: TextDocumentItem,
-        position: Position,
-        css_data: &CssCustomData,
-    ) -> Option<Hover> {
-        let store_entry = self.store.get_or_update_document(document);
+    pub fn get_hover(&self, document: TextDocumentItem, position: Position) -> Option<Hover> {
+        let css_custom_data = self.get_css_custom_data();
+        let store_entry = self.store.get(&document.uri);
 
-        extract_hover_information(
-            store_entry.css_tree.tree().syntax(),
-            position,
-            &store_entry.line_index,
-            self.encoding,
-            css_data,
-        )
+        match store_entry {
+            Some(store_entry) => Some(extract_hover_information(
+                store_entry.css_tree.tree().syntax(),
+                position,
+                &store_entry.line_index,
+                self.options.encoding,
+                &css_custom_data,
+            ))?,
+            None => None,
+        }
     }
 }
 
@@ -333,23 +342,15 @@ mod wasm_bindings {
     use super::extract_hover_information;
     use crate::{
         converters::{line_index::LineIndex, PositionEncoding, WideEncoding},
-        css_data::CssCustomData,
+        css_data::BASE_CSS_DATA,
         parser::parse_css,
         wasm_text_document::create_text_document,
     };
     use biome_rowan::AstNode;
     use lsp_types::Position;
-    use serde_json::from_str;
     use serde_wasm_bindgen;
-    use std::sync::LazyLock;
     use wasm_bindgen::prelude::*;
     extern crate console_error_panic_hook;
-
-    // TMP: Embed the JSON data at compile time
-    // We'll eventually use the language service when it'll be available in WASM
-    static CSS_SCHEMA_JSON: &str = include_str!("../../data/css-schema.json");
-    static CSS_DATA: LazyLock<CssCustomData> =
-        LazyLock::new(|| from_str(CSS_SCHEMA_JSON).expect("Failed to parse css-schema.json"));
 
     #[wasm_bindgen(typescript_custom_section)]
     const TS_APPEND_CONTENT: &'static str = r#"export async function get_hover(document: import("vscode-languageserver-textdocument").TextDocument, position: import("vscode-languageserver-types").Position): Promise<import("vscode-languageserver-types").Hover | null>;"#;
@@ -367,7 +368,7 @@ mod wasm_bindings {
             position,
             &line_index,
             encoding,
-            &CSS_DATA,
+            &vec![&BASE_CSS_DATA],
         );
 
         serde_wasm_bindgen::to_value(&hover).unwrap()

--- a/crates/csslsrs/src/service.rs
+++ b/crates/csslsrs/src/service.rs
@@ -1,38 +1,37 @@
-use crate::{converters::PositionEncoding, css_data::CssCustomData, store::DocumentStore};
-use serde_json;
-use std::sync::LazyLock;
+use crate::{
+    converters::PositionEncoding,
+    css_data::{CssCustomData, BASE_CSS_DATA, EMPTY_CSS_DATA},
+    store::DocumentStore,
+};
 
 /// The Language Service is the main entry point for interacting with CSSlsrs.
 /// It contains a DocumentStore, a PositionEncoding and a reference to the CSS data.
 pub struct LanguageService {
     pub store: DocumentStore,
-    pub encoding: PositionEncoding,
-    pub css_data: &'static CssCustomData,
+    pub options: LanguageServiceOptions,
+    base_css_data: &'static CssCustomData,
+    pub css_data: Vec<CssCustomData>,
 }
 
-static CSS_DATA: LazyLock<CssCustomData> =
-    LazyLock::new(
-        || match serde_json::from_str(include_str!("../data/css-schema.json")) {
-            Ok(data) => data,
-            Err(e) => panic!("Failed to parse CSS data: {}", e),
-        },
-    );
-
 impl LanguageService {
-    /// Create a new LanguageService with a default DocumentStore and a custom PositionEncoding.
+    /// Create a new LanguageService. This will create a {DocumentStore} internally. See {LanguageServiceOptions} for more information on the options available or {LanguageService::new_with_store} if you want to use an existing {DocumentStore}.
     ///
     /// ## Example
     /// ```rust
-    /// use csslsrs::service::LanguageService;
+    /// use csslsrs::service::{LanguageService, LanguageServiceOptions};
     /// use csslsrs::converters::PositionEncoding;
     ///
-    /// let language_service = LanguageService::new(PositionEncoding::Utf8);
+    /// let language_service = LanguageService::new(LanguageServiceOptions {
+    ///    encoding: PositionEncoding::Utf8,
+    ///    ..Default::default()
+    /// });
     /// ```
-    pub fn new(encoding: PositionEncoding) -> Self {
+    pub fn new(options: LanguageServiceOptions) -> Self {
         LanguageService {
             store: DocumentStore::new(),
-            encoding,
-            css_data: &CSS_DATA,
+            options,
+            base_css_data: &BASE_CSS_DATA,
+            css_data: vec![],
         }
     }
 
@@ -41,27 +40,92 @@ impl LanguageService {
     /// ## Example
     ///
     /// ```rust
-    /// use csslsrs::service::LanguageService;
+    /// use csslsrs::service::{LanguageService, LanguageServiceOptions};
     /// use csslsrs::store::DocumentStore;
     /// use csslsrs::converters::PositionEncoding;
     ///
     /// let store = DocumentStore::new();
     ///
-    /// let language_service = LanguageService::new_with_store(store, PositionEncoding::Utf8);
+    /// let language_service = LanguageService::new_with_store(LanguageServiceOptions::default(), store);
     /// ```
-    pub fn new_with_store(store: DocumentStore, encoding: PositionEncoding) -> Self {
+    pub fn new_with_store(options: LanguageServiceOptions, store: DocumentStore) -> Self {
         LanguageService {
             store,
-            encoding,
-            css_data: &CSS_DATA,
+            options,
+            base_css_data: {
+                if options.include_base_css_custom_data {
+                    &BASE_CSS_DATA
+                } else {
+                    &EMPTY_CSS_DATA
+                }
+            },
+            css_data: vec![],
         }
+    }
+
+    /// Add custom CSS data to the LanguageService. This can be useful to add custom CSS properties, at-rules, or pseudo-classes to the LanguageService.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// use csslsrs::service::{LanguageService, LanguageServiceOptions};
+    /// use csslsrs::css_data::CssCustomData;
+    /// use csslsrs::converters::PositionEncoding;
+    /// use csslsrs::css_data::{CssSection, AtDirectives, PseudoClasses, PseudoElements, Properties, PropertyEntry, PropertyAttributes};
+    ///
+    /// let mut language_service = LanguageService::new(LanguageServiceOptions::default());
+    ///
+    /// let custom_data = CssCustomData {
+    ///     css: CssSection {
+    ///         at_directives: AtDirectives { entry: vec![] },
+    ///         pseudo_classes: PseudoClasses { entry: vec![] },
+    ///         pseudo_elements: PseudoElements { entry: vec![] },
+    ///         properties: Properties { entry: vec![
+    ///             PropertyEntry {
+    ///                 attributes: PropertyAttributes {
+    ///                     name: "my-custom-property".to_string(),
+    ///                     restriction: None,
+    ///                     version: None,
+    ///                     browsers: None,
+    ///                     ref_: None,
+    ///                     syntax: None,
+    ///                 },
+    ///                 desc: None,
+    ///             }
+    ///         ] }
+    ///     }
+    /// };
+    ///
+    /// language_service.add_css_custom_data(custom_data);
+    /// ```
+    pub fn add_css_custom_data(&mut self, data: CssCustomData) {
+        self.css_data.push(data);
+    }
+
+    pub(crate) fn get_css_custom_data(&self) -> Vec<&CssCustomData> {
+        std::iter::once(self.base_css_data)
+            .chain(self.css_data.iter())
+            .collect()
     }
 }
 
 impl Default for LanguageService {
     fn default() -> Self {
-        LanguageService::new(PositionEncoding::Wide(
-            crate::converters::WideEncoding::Utf16,
-        ))
+        LanguageService::new(LanguageServiceOptions::default())
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct LanguageServiceOptions {
+    pub encoding: PositionEncoding,
+    pub include_base_css_custom_data: bool,
+}
+
+impl Default for LanguageServiceOptions {
+    fn default() -> Self {
+        LanguageServiceOptions {
+            encoding: PositionEncoding::Wide(crate::converters::WideEncoding::Utf16),
+            include_base_css_custom_data: true,
+        }
     }
 }

--- a/crates/csslsrs/src/service.rs
+++ b/crates/csslsrs/src/service.rs
@@ -103,6 +103,7 @@ impl LanguageService {
     }
 
     pub(crate) fn get_css_custom_data(&self) -> Vec<&CssCustomData> {
+        // Merge the base CSS data with the custom CSS data into a single vector for easier iteration
         std::iter::once(self.base_css_data)
             .chain(self.css_data.iter())
             .collect()

--- a/crates/csslsrs/tests/colors.rs
+++ b/crates/csslsrs/tests/colors.rs
@@ -347,6 +347,8 @@ fn assert_color_symbols(
         text: text.to_string(),
     };
 
+    ls.store.upsert_document(document.clone());
+
     let colors = ls.get_document_colors(document);
 
     assert_eq!(

--- a/crates/csslsrs/tests/folding.rs
+++ b/crates/csslsrs/tests/folding.rs
@@ -436,6 +436,8 @@ fn assert_folding_ranges(text: &str, expected_ranges: Vec<FoldingRange>) {
         text.to_string(),
     );
 
+    ls.store.upsert_document(document.clone());
+
     let mut folding_ranges = ls.get_folding_ranges(document);
 
     // Sort both actual and expected ranges by start_line for consistent comparison

--- a/crates/csslsrs/tests/hover.rs
+++ b/crates/csslsrs/tests/hover.rs
@@ -44,8 +44,12 @@ fn assert_hover(text_with_cursor: &str, expected_hover: Hover) {
         1,
         text.clone(),
     );
+
+    ls.store.upsert_document(document.clone());
+
     let position = offset_to_position(&text, offset);
-    let hover = ls.get_hover(document, position, ls.css_data);
+    let hover = ls.get_hover(document, position);
+
     assert_eq!(
         hover,
         Some(expected_hover),

--- a/crates/weblsp/src/css.rs
+++ b/crates/weblsp/src/css.rs
@@ -1,13 +1,13 @@
 use crate::cast;
-use csslsrs::converters::PositionEncoding;
 use csslsrs::service::LanguageService;
+use csslsrs::service::LanguageServiceOptions;
 use lsp_server::{Connection, Message, Request, Response};
 use std::error::Error;
 
 /// Initialize our CSS Language Service (CSSlsrs).
 /// Used once at the start of the main loop, so the document store stays alive throughout the server's lifetime.
 pub fn init_language_service() -> LanguageService {
-    LanguageService::new(PositionEncoding::Utf8)
+    LanguageService::new(LanguageServiceOptions::default())
 }
 
 /// Handle WEBlsp's CSS requests. This function will be called by the main loop when a CSS request is received,
@@ -54,7 +54,6 @@ pub fn handle_request(
                     language_service,
                 )?,
                 params.text_document_position_params.position,
-                language_service.css_data,
             );
             send_result(connection, id, serde_json::to_value(&hover).unwrap())?;
         }

--- a/crates/weblsp/src/notifications.rs
+++ b/crates/weblsp/src/notifications.rs
@@ -26,7 +26,7 @@ pub fn handle_notification(
                     );
                     css_language_service
                         .store
-                        .get_or_update_document(params.text_document);
+                        .upsert_document(params.text_document);
                 }
                 _ => {
                     eprintln!(
@@ -42,7 +42,7 @@ pub fn handle_notification(
                 serde_json::from_value(notification.params).unwrap();
             css_language_service
                 .store
-                .get_or_update_document(TextDocumentItem {
+                .upsert_document(TextDocumentItem {
                     uri: params.text_document.uri,
                     language_id: "css".to_string(),
                     version: params.text_document.version,

--- a/packages/csslsrs/test/features/hover.test.ts
+++ b/packages/csslsrs/test/features/hover.test.ts
@@ -1,41 +1,36 @@
-import { describe, it } from "mocha"
-import { expect } from "chai"
-import { TextDocument } from "vscode-languageserver-textdocument"
-import { get_hover } from "../../../csslsrs/dist/index"
-import cssCustomData from "../../../../crates/csslsrs/data/css-schema.json"
+import { describe, it } from "mocha";
+import { expect } from "chai";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { get_hover } from "../../../csslsrs/dist/index";
 
 describe("Hover", () => {
-  it("Can return hover", async () => {
-    const myDocument = TextDocument.create(
-      "file:///test.css",
-      "css",
-      0,
-      `body {
+	it("Can return hover", async () => {
+		const myDocument = TextDocument.create(
+			"file:///test.css",
+			"css",
+			0,
+			`body {
   background-color: #fff;
     }`
-    )
-    const hover = await get_hover(
-      myDocument,
-      { line: 0, character: 3 },
-      cssCustomData
-    )
+		);
+		const hover = await get_hover(myDocument, { line: 0, character: 3 });
 
-    expect(hover).to.deep.equal({
-      contents: {
-        kind: "markdown",
-        value:
-          "**body**\n\n[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 0, 1)\n\n",
-      },
-      range: {
-        start: {
-          line: 0,
-          character: 0,
-        },
-        end: {
-          line: 0,
-          character: 4,
-        },
-      },
-    })
-  })
-})
+		expect(hover).to.deep.equal({
+			contents: {
+				kind: "markdown",
+				value:
+					"**body**\n\n[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 0, 1)\n\n",
+			},
+			range: {
+				start: {
+					line: 0,
+					character: 0,
+				},
+				end: {
+					line: 0,
+					character: 4,
+				},
+			},
+		});
+	});
+});


### PR DESCRIPTION
## What does this change?

Update language service to take a vec of custom data instead of a defined one. WASM doesn't have access to this yet, but this PR also prepares for that eventually.

This PR also includes a refactors to the document handling inside of the document store, following previous work I'd done in https://github.com/web-lsp/csslsrs/pull/6 for perf reasons

## How is it tested?

Tests should still pass, updated ones that needed to use new options

## How is it documented?

Updated docs for affected methods