### PR TITLE
feat(wasm): Add support for language service

### DIFF
--- a/crates/csslsrs/benches/features/color.rs
+++ b/crates/csslsrs/benches/features/color.rs
@@ -36,7 +36,7 @@ fn get_color_presentations_benchmark(c: &mut Criterion) {
     let color = colors.first().unwrap();
 
     c.bench_function("get_color_presentations", |b| {
-        b.iter(|| ls.get_color_presentations(black_box(color.clone()), black_box(color.range)))
+        b.iter(|| ls.get_color_presentations(black_box(color.clone())))
     });
 }
 

--- a/crates/csslsrs/benches/features/color.rs
+++ b/crates/csslsrs/benches/features/color.rs
@@ -13,7 +13,7 @@ fn get_colors_benchmark(c: &mut Criterion) {
         text: "body { color: red; }".to_string(),
     };
 
-    ls.store.upsert_document(document.clone());
+    ls.upsert_document(document.clone());
 
     c.bench_function("get_document_colors", |b| {
         b.iter(|| ls.get_document_colors(black_box(document.clone())))
@@ -30,7 +30,7 @@ fn get_color_presentations_benchmark(c: &mut Criterion) {
         text: "body { color: red; }".to_string(),
     };
 
-    ls.store.upsert_document(document.clone());
+    ls.upsert_document(document.clone());
 
     let colors = ls.get_document_colors(document);
     let color = colors.first().unwrap();

--- a/crates/csslsrs/benches/features/folding.rs
+++ b/crates/csslsrs/benches/features/folding.rs
@@ -48,7 +48,7 @@ fn get_folding_ranges_benchmark(c: &mut Criterion) {
         text: TEST_CASE.to_string(),
     };
 
-    ls.store.upsert_document(document.clone());
+    ls.upsert_document(document.clone());
 
     c.bench_function("get_folding_ranges", |b| {
         b.iter(|| ls.get_folding_ranges(black_box(document.clone())))

--- a/crates/csslsrs/benches/features/hover.rs
+++ b/crates/csslsrs/benches/features/hover.rs
@@ -13,7 +13,7 @@ fn get_hover_benchmark(c: &mut Criterion) {
         text: "body { color: red; }".to_string(),
     };
 
-    ls.store.upsert_document(document.clone());
+    ls.upsert_document(document.clone());
 
     c.bench_function("get_hover", |b| {
         b.iter(|| ls.get_hover(black_box(document.clone()), lsp_types::Position::new(0, 8)))

--- a/crates/csslsrs/src/converters/from_proto.rs
+++ b/crates/csslsrs/src/converters/from_proto.rs
@@ -13,12 +13,12 @@ pub(crate) fn offset(
             line: position.line,
             col: position.character,
         },
-        PositionEncoding::Wide(enc) => {
+        PositionEncoding::Utf16 | PositionEncoding::Utf32 => {
             let line_col = WideLineCol {
                 line: position.line,
                 col: position.character,
             };
-            line_index.to_utf8(enc, line_col)
+            line_index.to_utf8(position_encoding, line_col)
         }
     };
 

--- a/crates/csslsrs/src/converters/line_index.rs
+++ b/crates/csslsrs/src/converters/line_index.rs
@@ -3,9 +3,11 @@
 
 use std::mem;
 
-use crate::converters::{LineCol, WideChar, WideEncoding, WideLineCol};
+use crate::converters::{LineCol, WideChar, WideLineCol};
 use biome_rowan::TextSize;
 use rustc_hash::FxHashMap;
+
+use super::PositionEncoding;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct LineIndex {
@@ -90,7 +92,7 @@ impl LineIndex {
             .map(|offset| offset + TextSize::from(line_col.col))
     }
 
-    pub fn to_wide(&self, enc: WideEncoding, line_col: LineCol) -> Option<WideLineCol> {
+    pub fn to_wide(&self, enc: PositionEncoding, line_col: LineCol) -> Option<WideLineCol> {
         let col = self.utf8_to_wide_col(enc, line_col.line, line_col.col.into());
         Some(WideLineCol {
             line: line_col.line,
@@ -99,7 +101,7 @@ impl LineIndex {
     }
 
     #[allow(dead_code)]
-    pub fn to_utf8(&self, enc: WideEncoding, line_col: WideLineCol) -> LineCol {
+    pub fn to_utf8(&self, enc: PositionEncoding, line_col: WideLineCol) -> LineCol {
         let col = self.wide_to_utf8_col(enc, line_col.line, line_col.col);
         LineCol {
             line: line_col.line,
@@ -107,7 +109,7 @@ impl LineIndex {
         }
     }
 
-    fn utf8_to_wide_col(&self, enc: WideEncoding, line: u32, col: TextSize) -> usize {
+    fn utf8_to_wide_col(&self, enc: PositionEncoding, line: u32, col: TextSize) -> usize {
         let mut res: usize = col.into();
         if let Some(wide_chars) = self.line_wide_chars.get(&line) {
             for c in wide_chars {
@@ -123,7 +125,7 @@ impl LineIndex {
         res
     }
 
-    fn wide_to_utf8_col(&self, enc: WideEncoding, line: u32, mut col: u32) -> TextSize {
+    fn wide_to_utf8_col(&self, enc: PositionEncoding, line: u32, mut col: u32) -> TextSize {
         if let Some(wide_chars) = self.line_wide_chars.get(&line) {
             for c in wide_chars {
                 if col > u32::from(c.start) {

--- a/crates/csslsrs/src/converters/mod.rs
+++ b/crates/csslsrs/src/converters/mod.rs
@@ -1,17 +1,16 @@
 use biome_rowan::TextSize;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::wasm_bindgen;
 
 pub(crate) mod from_proto;
 pub(crate) mod line_index;
 pub(crate) mod to_proto;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Default)]
+#[wasm_bindgen]
 pub enum PositionEncoding {
     Utf8,
-    Wide(WideEncoding),
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum WideEncoding {
+    #[default]
     Utf16,
     Utf32,
 }
@@ -48,9 +47,10 @@ impl WideChar {
     }
 
     /// Returns the length in UTF-16 or UTF-32 code units.
-    fn wide_len(&self, enc: WideEncoding) -> usize {
+    fn wide_len(&self, enc: PositionEncoding) -> usize {
         match enc {
-            WideEncoding::Utf16 => {
+            PositionEncoding::Utf8 => panic!("Encoding isn't wide"),
+            PositionEncoding::Utf16 => {
                 if self.len() == TextSize::from(4) {
                     2
                 } else {
@@ -58,7 +58,7 @@ impl WideChar {
                 }
             }
 
-            WideEncoding::Utf32 => 1,
+            PositionEncoding::Utf32 => 1,
         }
     }
 }
@@ -68,14 +68,14 @@ mod tests {
     use crate::converters::from_proto::offset;
     use crate::converters::line_index::LineIndex;
     use crate::converters::to_proto::position;
-    use crate::converters::WideEncoding::{Utf16, Utf32};
-    use crate::converters::{LineCol, PositionEncoding, WideEncoding};
+    use crate::converters::PositionEncoding::{Utf16, Utf32};
+    use crate::converters::{LineCol, PositionEncoding};
     use biome_rowan::TextSize;
     use lsp_types::Position;
 
     macro_rules! check_conversion {
         ($line_index:ident : $position:expr => $text_size:expr ) => {
-            let position_encoding = PositionEncoding::Wide(WideEncoding::Utf16);
+            let position_encoding = PositionEncoding::Utf16;
 
             let offset = offset(&$line_index, $position, position_encoding).ok();
             assert_eq!(offset, Some($text_size));
@@ -155,6 +155,7 @@ mod tests {
                 let want_col = match enc {
                     Utf16 => col_utf16,
                     Utf32 => col_utf32,
+                    _ => unreachable!(),
                 };
                 assert_eq!(wide_lin_col.col, want_col)
             }

--- a/crates/csslsrs/src/converters/mod.rs
+++ b/crates/csslsrs/src/converters/mod.rs
@@ -1,5 +1,6 @@
 use biome_rowan::TextSize;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
 pub(crate) mod from_proto;
@@ -7,7 +8,7 @@ pub(crate) mod line_index;
 pub(crate) mod to_proto;
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, Default)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub enum PositionEncoding {
     Utf8,
     #[default]

--- a/crates/csslsrs/src/converters/to_proto.rs
+++ b/crates/csslsrs/src/converters/to_proto.rs
@@ -12,8 +12,8 @@ pub(crate) fn position(
 
     let position = match position_encoding {
         PositionEncoding::Utf8 => lsp_types::Position::new(line_col.line, line_col.col),
-        PositionEncoding::Wide(enc) => {
-            let line_col = line_index.to_wide(enc, line_col).ok_or(())?;
+        PositionEncoding::Utf16 | PositionEncoding::Utf32 => {
+            let line_col = line_index.to_wide(position_encoding, line_col).ok_or(())?;
             lsp_types::Position::new(line_col.line, line_col.col)
         }
     };

--- a/crates/csslsrs/src/features/colors.rs
+++ b/crates/csslsrs/src/features/colors.rs
@@ -163,8 +163,7 @@ mod wasm_bindings {
     #[wasm_bindgen]
     impl WASMLanguageService {
         #[wasm_bindgen]
-        pub fn get_document_colors(&self, document: JsValue) -> JsValue {
-            let document_uri = document.as_string().unwrap();
+        pub fn get_document_colors(&self, document_uri: String) -> JsValue {
             let store_document = self.store.get(&Uri::from_str(&document_uri).unwrap());
 
             let document_colors = match store_document {

--- a/crates/csslsrs/src/features/colors.rs
+++ b/crates/csslsrs/src/features/colors.rs
@@ -151,11 +151,12 @@ impl LanguageService {
 
 #[cfg(feature = "wasm")]
 mod wasm_bindings {
-    use crate::{
-        service::wasm_bindings::WASMLanguageService, wasm_text_document::create_text_document,
-    };
+    use std::str::FromStr;
+
+    use crate::service::wasm_bindings::WASMLanguageService;
 
     use super::{compute_color_presentations, find_document_colors};
+    use lsp_types::Uri;
     use serde_wasm_bindgen;
     use wasm_bindgen::prelude::*;
 
@@ -163,8 +164,8 @@ mod wasm_bindings {
     impl WASMLanguageService {
         #[wasm_bindgen]
         pub fn get_document_colors(&self, document: JsValue) -> JsValue {
-            let document = create_text_document(document);
-            let store_document = self.store.get(&document.uri);
+            let document_uri = document.as_string().unwrap();
+            let store_document = self.store.get(&Uri::from_str(&document_uri).unwrap());
 
             let document_colors = match store_document {
                 Some(store_document) => find_document_colors(

--- a/crates/csslsrs/src/features/colors.rs
+++ b/crates/csslsrs/src/features/colors.rs
@@ -1,7 +1,7 @@
 use biome_css_parser::CssParse;
 use biome_css_syntax::{CssLanguage, CssSyntaxKind};
 use biome_rowan::{AstNode, SyntaxNode};
-use lsp_types::{ColorInformation, ColorPresentation, Range, TextDocumentItem, TextEdit};
+use lsp_types::{ColorInformation, ColorPresentation, TextDocumentItem, TextEdit};
 use palette::{named, Hsla, Hwba, Laba, Lcha, Srgba, WithAlpha};
 
 use crate::{
@@ -84,7 +84,7 @@ fn find_document_colors(
     extract_colors_information(binding.syntax(), line_index, encoding)
 }
 
-fn compute_color_presentations(color: ColorInformation, range: Range) -> Vec<ColorPresentation> {
+fn compute_color_presentations(color: ColorInformation) -> Vec<ColorPresentation> {
     let rgb_color = Srgba::from_lsp_color(color.color);
 
     let mut color_texts: Vec<String> = vec![];
@@ -120,7 +120,7 @@ fn compute_color_presentations(color: ColorInformation, range: Range) -> Vec<Col
         .map(|text| ColorPresentation {
             label: text.clone(),
             text_edit: Some(TextEdit {
-                range,
+                range: color.range,
                 new_text: text,
             }),
             additional_text_edits: None,
@@ -144,50 +144,46 @@ impl LanguageService {
         }
     }
 
-    pub fn get_color_presentations(
-        &self,
-        color: ColorInformation,
-        range: Range,
-    ) -> Vec<ColorPresentation> {
-        compute_color_presentations(color, range)
+    pub fn get_color_presentations(&self, color: ColorInformation) -> Vec<ColorPresentation> {
+        compute_color_presentations(color)
     }
 }
 
 #[cfg(feature = "wasm")]
 mod wasm_bindings {
     use crate::{
-        converters::{line_index::LineIndex, PositionEncoding},
-        parser::parse_css,
+        service::wasm_bindings::WASMLanguageService, wasm_text_document::create_text_document,
     };
 
     use super::{compute_color_presentations, find_document_colors};
     use serde_wasm_bindgen;
     use wasm_bindgen::prelude::*;
 
-    #[wasm_bindgen(typescript_custom_section)]
-    const TS_APPEND_CONTENT: &'static str = r#"export async function get_document_colors(source: import("vscode-languageserver-textdocument").TextDocument): Promise<import("vscode-languageserver-types").ColorInformation[]>;"#;
+    #[wasm_bindgen]
+    impl WASMLanguageService {
+        #[wasm_bindgen]
+        pub fn get_document_colors(&self, document: JsValue) -> JsValue {
+            let document = create_text_document(document);
+            let store_document = self.store.get(&document.uri);
 
-    #[wasm_bindgen(skip_typescript)]
-    pub fn get_document_colors(document: JsValue) -> JsValue {
-        let parsed_text_document = crate::wasm_text_document::create_text_document(document);
-        let document_colors = find_document_colors(
-            &parse_css(&parsed_text_document.text),
-            &LineIndex::new(&parsed_text_document.text),
-            PositionEncoding::Wide(crate::converters::WideEncoding::Utf16),
-        );
+            let document_colors = match store_document {
+                Some(store_document) => find_document_colors(
+                    &store_document.css_tree,
+                    &store_document.line_index,
+                    self.options.encoding,
+                ),
+                None => vec![],
+            };
 
-        serde_wasm_bindgen::to_value(&document_colors).unwrap()
-    }
+            serde_wasm_bindgen::to_value(&document_colors).unwrap()
+        }
 
-    #[wasm_bindgen(typescript_custom_section)]
-    const TS_APPEND_CONTENT: &'static str = r#"export async function get_color_presentations(color: import("vscode-languageserver-types").ColorInformation, range: import("vscode-languageserver-types").Range): Promise<import("vscode-languageserver-types").ColorPresentation[]>;"#;
+        #[wasm_bindgen]
+        pub fn get_color_presentations(&self, color: JsValue) -> JsValue {
+            let color = serde_wasm_bindgen::from_value(color).unwrap();
+            let color_presentations = compute_color_presentations(color);
 
-    #[wasm_bindgen(skip_typescript)]
-    pub fn get_color_presentations(color: JsValue, range: JsValue) -> JsValue {
-        let color = serde_wasm_bindgen::from_value(color).unwrap();
-        let range = serde_wasm_bindgen::from_value(range).unwrap();
-        let color_presentations = compute_color_presentations(color, range);
-
-        serde_wasm_bindgen::to_value(&color_presentations).unwrap()
+            serde_wasm_bindgen::to_value(&color_presentations).unwrap()
+        }
     }
 }

--- a/crates/csslsrs/src/features/colors.rs
+++ b/crates/csslsrs/src/features/colors.rs
@@ -160,9 +160,15 @@ mod wasm_bindings {
     use serde_wasm_bindgen;
     use wasm_bindgen::prelude::*;
 
+    #[wasm_bindgen(typescript_custom_section)]
+    const TS_APPEND_CONTENT: &'static str = r#"
+        declare function get_document_colors(documentUri: string): import("vscode-languageserver-types").ColorInformation[];
+        declare function get_color_presentations(color: import("vscode-languageserver-types").ColorInformation): import("vscode-languageserver-types").ColorPresentation[];
+    "#;
+
     #[wasm_bindgen]
     impl WASMLanguageService {
-        #[wasm_bindgen]
+        #[wasm_bindgen(skip_typescript, js_name = getDocumentColors)]
         pub fn get_document_colors(&self, document_uri: String) -> JsValue {
             let store_document = self.store.get(&Uri::from_str(&document_uri).unwrap());
 
@@ -178,7 +184,7 @@ mod wasm_bindings {
             serde_wasm_bindgen::to_value(&document_colors).unwrap()
         }
 
-        #[wasm_bindgen]
+        #[wasm_bindgen(skip_typescript, js_name = getColorPresentations)]
         pub fn get_color_presentations(&self, color: JsValue) -> JsValue {
             let color = serde_wasm_bindgen::from_value(color).unwrap();
             let color_presentations = compute_color_presentations(color);

--- a/crates/csslsrs/src/features/folding.rs
+++ b/crates/csslsrs/src/features/folding.rs
@@ -181,30 +181,26 @@ impl LanguageService {
 #[cfg(feature = "wasm")]
 mod wasm_bindings {
     use super::compute_folding_ranges;
-    use crate::converters::line_index::LineIndex;
-    use serde_wasm_bindgen;
+    use crate::{
+        service::wasm_bindings::WASMLanguageService, wasm_text_document::create_text_document,
+    };
     use wasm_bindgen::prelude::*;
 
-    #[wasm_bindgen(typescript_custom_section)]
-    const TS_APPEND_CONTENT: &'static str = r#"
-/**
- * Get the folding ranges for the given CSS source code. It supports CSS blocks enclosed in
- * braces, multi-line comments, and regions marked with `#region` and `#endregion` comments.
- *
- * @param source The CSS source code as a `TextDocument`.
- * @returns A list of `FoldingRange` objects indicating the foldable regions in the CSS code.
- */
-export async function get_folding_ranges(source: import("vscode-languageserver-textdocument").TextDocument): Promise<import("vscode-languageserver-types").FoldingRange[]>;
-"#;
+    #[wasm_bindgen]
+    impl WASMLanguageService {
+        #[wasm_bindgen]
+        pub fn get_folding_ranges(&self, document: JsValue) -> JsValue {
+            let document = create_text_document(document);
+            let store_document = self.store.get(&document.uri);
 
-    #[wasm_bindgen(skip_typescript)]
-    pub fn get_folding_ranges(document: JsValue) -> JsValue {
-        let parsed_text_document = crate::wasm_text_document::create_text_document(document);
-        let folding_ranges = compute_folding_ranges(
-            &parsed_text_document,
-            &LineIndex::new(&parsed_text_document.text),
-        );
+            let folding_ranges = match store_document {
+                Some(store_document) => {
+                    compute_folding_ranges(&store_document.document, &store_document.line_index)
+                }
+                None => Vec::new(),
+            };
 
-        serde_wasm_bindgen::to_value(&folding_ranges).unwrap()
+            serde_wasm_bindgen::to_value(&folding_ranges).unwrap()
+        }
     }
 }

--- a/crates/csslsrs/src/features/folding.rs
+++ b/crates/csslsrs/src/features/folding.rs
@@ -190,8 +190,7 @@ mod wasm_bindings {
     #[wasm_bindgen]
     impl WASMLanguageService {
         #[wasm_bindgen]
-        pub fn get_folding_ranges(&self, document: JsValue) -> JsValue {
-            let document_uri = document.as_string().unwrap();
+        pub fn get_folding_ranges(&self, document_uri: String) -> JsValue {
             let store_document = self.store.get(&Uri::from_str(&document_uri).unwrap());
 
             let folding_ranges = match store_document {

--- a/crates/csslsrs/src/features/folding.rs
+++ b/crates/csslsrs/src/features/folding.rs
@@ -180,18 +180,19 @@ impl LanguageService {
 
 #[cfg(feature = "wasm")]
 mod wasm_bindings {
+    use std::str::FromStr;
+
     use super::compute_folding_ranges;
-    use crate::{
-        service::wasm_bindings::WASMLanguageService, wasm_text_document::create_text_document,
-    };
+    use crate::service::wasm_bindings::WASMLanguageService;
+    use lsp_types::Uri;
     use wasm_bindgen::prelude::*;
 
     #[wasm_bindgen]
     impl WASMLanguageService {
         #[wasm_bindgen]
         pub fn get_folding_ranges(&self, document: JsValue) -> JsValue {
-            let document = create_text_document(document);
-            let store_document = self.store.get(&document.uri);
+            let document_uri = document.as_string().unwrap();
+            let store_document = self.store.get(&Uri::from_str(&document_uri).unwrap());
 
             let folding_ranges = match store_document {
                 Some(store_document) => {

--- a/crates/csslsrs/src/features/folding.rs
+++ b/crates/csslsrs/src/features/folding.rs
@@ -187,9 +187,14 @@ mod wasm_bindings {
     use lsp_types::Uri;
     use wasm_bindgen::prelude::*;
 
+    #[wasm_bindgen(typescript_custom_section)]
+    const TS_APPEND_CONTENT: &'static str = r#"
+        declare function get_folding_ranges(documentUri: string): import("vscode-languageserver-types").FoldingRange[];
+    "#;
+
     #[wasm_bindgen]
     impl WASMLanguageService {
-        #[wasm_bindgen]
+        #[wasm_bindgen(skip_typescript, js_name = getFoldingRanges)]
         pub fn get_folding_ranges(&self, document_uri: String) -> JsValue {
             let store_document = self.store.get(&Uri::from_str(&document_uri).unwrap());
 

--- a/crates/csslsrs/src/features/hover.rs
+++ b/crates/csslsrs/src/features/hover.rs
@@ -338,12 +338,12 @@ impl LanguageService {
 
 #[cfg(feature = "wasm")]
 mod wasm_bindings {
+    use std::str::FromStr;
+
     use super::extract_hover_information;
-    use crate::{
-        service::wasm_bindings::WASMLanguageService, wasm_text_document::create_text_document,
-    };
+    use crate::service::wasm_bindings::WASMLanguageService;
     use biome_rowan::AstNode;
-    use lsp_types::Position;
+    use lsp_types::{Position, Uri};
     use serde_wasm_bindgen;
     use wasm_bindgen::prelude::*;
 
@@ -351,8 +351,8 @@ mod wasm_bindings {
     impl WASMLanguageService {
         #[wasm_bindgen]
         pub fn get_hover(&self, document: JsValue, position: JsValue) -> JsValue {
-            let document = create_text_document(document);
-            let store_document = self.store.get(&document.uri);
+            let document_uri = document.as_string().unwrap();
+            let store_document = self.store.get(&Uri::from_str(&document_uri).unwrap());
 
             let hover_info = match store_document {
                 Some(store_document) => {

--- a/crates/csslsrs/src/features/hover.rs
+++ b/crates/csslsrs/src/features/hover.rs
@@ -350,7 +350,6 @@ mod wasm_bindings {
     use lsp_types::Position;
     use serde_wasm_bindgen;
     use wasm_bindgen::prelude::*;
-    extern crate console_error_panic_hook;
 
     #[wasm_bindgen(typescript_custom_section)]
     const TS_APPEND_CONTENT: &'static str = r#"export async function get_hover(document: import("vscode-languageserver-textdocument").TextDocument, position: import("vscode-languageserver-types").Position): Promise<import("vscode-languageserver-types").Hover | null>;"#;

--- a/crates/csslsrs/src/features/hover.rs
+++ b/crates/csslsrs/src/features/hover.rs
@@ -347,9 +347,14 @@ mod wasm_bindings {
     use serde_wasm_bindgen;
     use wasm_bindgen::prelude::*;
 
+    #[wasm_bindgen(typescript_custom_section)]
+    const TS_APPEND_CONTENT: &'static str = r#"
+        declare function get_hover(documentUri: string, position:  import("vscode-languageserver-types").Position): import("vscode-languageserver-types").FoldingRange[];
+    "#;
+
     #[wasm_bindgen]
     impl WASMLanguageService {
-        #[wasm_bindgen]
+        #[wasm_bindgen(skip_typescript, js_name = getHover)]
         pub fn get_hover(&self, document_uri: String, position: JsValue) -> JsValue {
             let store_document = self.store.get(&Uri::from_str(&document_uri).unwrap());
 

--- a/crates/csslsrs/src/features/hover.rs
+++ b/crates/csslsrs/src/features/hover.rs
@@ -350,8 +350,7 @@ mod wasm_bindings {
     #[wasm_bindgen]
     impl WASMLanguageService {
         #[wasm_bindgen]
-        pub fn get_hover(&self, document: JsValue, position: JsValue) -> JsValue {
-            let document_uri = document.as_string().unwrap();
+        pub fn get_hover(&self, document_uri: String, position: JsValue) -> JsValue {
             let store_document = self.store.get(&Uri::from_str(&document_uri).unwrap());
 
             let hover_info = match store_document {

--- a/crates/csslsrs/src/features/hover.rs
+++ b/crates/csslsrs/src/features/hover.rs
@@ -321,7 +321,6 @@ fn is_identifier_char(c: char) -> bool {
 impl LanguageService {
     /// Gets the hover information for the given CSS document and position.
     pub fn get_hover(&self, document: TextDocumentItem, position: Position) -> Option<Hover> {
-        let css_custom_data = self.get_css_custom_data();
         let store_entry = self.store.get(&document.uri);
 
         match store_entry {
@@ -330,7 +329,7 @@ impl LanguageService {
                 position,
                 &store_entry.line_index,
                 self.options.encoding,
-                &css_custom_data,
+                &self.get_css_custom_data(),
             ))?,
             None => None,
         }
@@ -341,35 +340,36 @@ impl LanguageService {
 mod wasm_bindings {
     use super::extract_hover_information;
     use crate::{
-        converters::{line_index::LineIndex, PositionEncoding, WideEncoding},
-        css_data::BASE_CSS_DATA,
-        parser::parse_css,
-        wasm_text_document::create_text_document,
+        service::wasm_bindings::WASMLanguageService, wasm_text_document::create_text_document,
     };
     use biome_rowan::AstNode;
     use lsp_types::Position;
     use serde_wasm_bindgen;
     use wasm_bindgen::prelude::*;
 
-    #[wasm_bindgen(typescript_custom_section)]
-    const TS_APPEND_CONTENT: &'static str = r#"export async function get_hover(document: import("vscode-languageserver-textdocument").TextDocument, position: import("vscode-languageserver-types").Position): Promise<import("vscode-languageserver-types").Hover | null>;"#;
+    #[wasm_bindgen]
+    impl WASMLanguageService {
+        #[wasm_bindgen]
+        pub fn get_hover(&self, document: JsValue, position: JsValue) -> JsValue {
+            let document = create_text_document(document);
+            let store_document = self.store.get(&document.uri);
 
-    #[wasm_bindgen(skip_typescript)]
-    pub fn get_hover(document: JsValue, position: JsValue) -> JsValue {
-        let parsed_text_document = create_text_document(document);
-        let position: Position = serde_wasm_bindgen::from_value(position).unwrap();
-        let css_parse = parse_css(&parsed_text_document.text);
-        let line_index = LineIndex::new(&parsed_text_document.text);
-        let encoding = PositionEncoding::Wide(WideEncoding::Utf16);
+            let hover_info = match store_document {
+                Some(store_document) => {
+                    let position: Position = serde_wasm_bindgen::from_value(position).unwrap();
 
-        let hover = extract_hover_information(
-            css_parse.tree().syntax(),
-            position,
-            &line_index,
-            encoding,
-            &vec![&BASE_CSS_DATA],
-        );
+                    extract_hover_information(
+                        store_document.css_tree.tree().syntax(),
+                        position,
+                        &store_document.line_index,
+                        self.options.encoding,
+                        &self.get_css_custom_data(),
+                    )
+                }
+                None => None,
+            };
 
-        serde_wasm_bindgen::to_value(&hover).unwrap()
+            serde_wasm_bindgen::to_value(&hover_info).unwrap()
+        }
     }
 }

--- a/crates/csslsrs/src/service.rs
+++ b/crates/csslsrs/src/service.rs
@@ -1,18 +1,23 @@
 use crate::{
     converters::PositionEncoding,
     css_data::{CssCustomData, BASE_CSS_DATA, EMPTY_CSS_DATA},
-    store::DocumentStore,
+    store::{DocumentStore, StoreEntry},
 };
+use lsp_types::{TextDocumentItem, Uri};
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
 
 /// The Language Service is the main entry point for interacting with CSSlsrs.
 /// It contains a DocumentStore, a PositionEncoding and a reference to the CSS data.
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub struct LanguageService {
-    pub store: DocumentStore,
-    pub options: LanguageServiceOptions,
+    pub(crate) store: DocumentStore,
+    pub(crate) options: LanguageServiceOptions,
     base_css_data: &'static CssCustomData,
-    pub css_data: Vec<CssCustomData>,
+    pub(crate) css_data: Vec<CssCustomData>,
 }
 
+#[cfg(not(feature = "wasm"))]
 impl LanguageService {
     /// Create a new LanguageService. This will create a {DocumentStore} internally. See {LanguageServiceOptions} for more information on the options available or {LanguageService::new_with_store} if you want to use an existing {DocumentStore}.
     ///
@@ -30,7 +35,13 @@ impl LanguageService {
         LanguageService {
             store: DocumentStore::new(),
             options,
-            base_css_data: &BASE_CSS_DATA,
+            base_css_data: {
+                if options.include_base_css_custom_data {
+                    &BASE_CSS_DATA
+                } else {
+                    &EMPTY_CSS_DATA
+                }
+            },
             css_data: vec![],
         }
     }
@@ -101,15 +112,26 @@ impl LanguageService {
     pub fn add_css_custom_data(&mut self, data: CssCustomData) {
         self.css_data.push(data);
     }
+}
 
+impl LanguageService {
     pub(crate) fn get_css_custom_data(&self) -> Vec<&CssCustomData> {
         // Merge the base CSS data with the custom CSS data into a single vector for easier iteration
         std::iter::once(self.base_css_data)
             .chain(self.css_data.iter())
             .collect()
     }
+
+    pub fn get_document(&self, uri: &Uri) -> Option<&StoreEntry> {
+        self.store.get(uri)
+    }
+
+    pub fn upsert_document(&mut self, document: TextDocumentItem) -> &StoreEntry {
+        self.store.upsert_document(document)
+    }
 }
 
+#[cfg(not(feature = "wasm"))]
 impl Default for LanguageService {
     fn default() -> Self {
         LanguageService::new(LanguageServiceOptions::default())
@@ -127,6 +149,92 @@ impl Default for LanguageServiceOptions {
         LanguageServiceOptions {
             encoding: PositionEncoding::Wide(crate::converters::WideEncoding::Utf16),
             include_base_css_custom_data: true,
+        }
+    }
+}
+
+#[cfg(feature = "wasm")]
+mod wasm_bindings {
+    use serde::{Deserialize, Serialize};
+    use wasm_bindgen::prelude::wasm_bindgen;
+
+    use crate::converters::PositionEncoding;
+    use crate::service::{BASE_CSS_DATA, EMPTY_CSS_DATA};
+    use crate::store::DocumentStore;
+
+    use super::{LanguageService, LanguageServiceOptions};
+
+    #[wasm_bindgen]
+    impl LanguageService {
+        #[wasm_bindgen(constructor)]
+        pub fn new(options: JSLanguageServiceOptions) -> Self {
+            let include_base_css_custom_data = options.include_base_css_custom_data;
+
+            LanguageService {
+                store: DocumentStore::new(),
+                options: options.into(),
+                base_css_data: {
+                    if include_base_css_custom_data {
+                        &BASE_CSS_DATA
+                    } else {
+                        &EMPTY_CSS_DATA
+                    }
+                },
+                css_data: vec![],
+            }
+        }
+    }
+
+    impl Default for LanguageService {
+        fn default() -> Self {
+            LanguageService::new(JSLanguageServiceOptions::default())
+        }
+    }
+
+    #[wasm_bindgen]
+    #[derive(Deserialize, Serialize)]
+    pub enum JSPositionEncoding {
+        Utf8,
+        Utf16,
+        Utf32,
+    }
+
+    impl From<JSPositionEncoding> for PositionEncoding {
+        fn from(js_encoding: JSPositionEncoding) -> Self {
+            match js_encoding {
+                JSPositionEncoding::Utf8 => PositionEncoding::Utf8,
+                JSPositionEncoding::Utf16 => {
+                    PositionEncoding::Wide(crate::converters::WideEncoding::Utf16)
+                }
+                JSPositionEncoding::Utf32 => {
+                    PositionEncoding::Wide(crate::converters::WideEncoding::Utf32)
+                }
+            }
+        }
+    }
+
+    #[derive(Deserialize, Serialize)]
+    #[wasm_bindgen]
+    pub struct JSLanguageServiceOptions {
+        encoding: JSPositionEncoding,
+        include_base_css_custom_data: bool,
+    }
+
+    impl Default for JSLanguageServiceOptions {
+        fn default() -> Self {
+            JSLanguageServiceOptions {
+                encoding: JSPositionEncoding::Utf16,
+                include_base_css_custom_data: true,
+            }
+        }
+    }
+
+    impl From<JSLanguageServiceOptions> for LanguageServiceOptions {
+        fn from(js_options: JSLanguageServiceOptions) -> Self {
+            LanguageServiceOptions {
+                encoding: js_options.encoding.into(),
+                include_base_css_custom_data: js_options.include_base_css_custom_data,
+            }
         }
     }
 }

--- a/crates/csslsrs/src/store.rs
+++ b/crates/csslsrs/src/store.rs
@@ -1,3 +1,6 @@
+// TODO: Split this off to a separate crate, as it's not specific to CSSlsrs.
+// Ideally, this would be generic, so that HTML, CSS, MD etc. could all use the same store, allowing for cross-language features.
+
 use std::collections::hash_map::Entry;
 
 use biome_css_parser::CssParse;

--- a/crates/csslsrs/src/wasm_text_document.rs
+++ b/crates/csslsrs/src/wasm_text_document.rs
@@ -5,13 +5,13 @@ use wasm_bindgen::prelude::*;
 
 /// Convert a JS object to a TextDocumentItem.
 pub fn create_text_document(js_value: JsValue) -> TextDocumentItem {
-    let js_text_document: JSTextDocument = serde_wasm_bindgen::from_value(js_value).unwrap();
+    let js_text_document: VSCodeTextDocument = serde_wasm_bindgen::from_value(js_value).unwrap();
 
     js_text_document.into()
 }
 
-impl From<JSTextDocument> for TextDocumentItem {
-    fn from(val: JSTextDocument) -> Self {
+impl From<VSCodeTextDocument> for TextDocumentItem {
+    fn from(val: VSCodeTextDocument) -> Self {
         TextDocumentItem {
             uri: val.uri,
             language_id: val.language_id,
@@ -25,7 +25,7 @@ impl From<JSTextDocument> for TextDocumentItem {
 /// and deserialization of text documents we need to use a custom struct in between. Bit annoying but it works.
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct JSTextDocument {
+struct VSCodeTextDocument {
     /// The text document's URI.
     pub uri: Uri,
 

--- a/crates/csslsrs/src/wasm_text_document.rs
+++ b/crates/csslsrs/src/wasm_text_document.rs
@@ -7,17 +7,23 @@ use wasm_bindgen::prelude::*;
 pub fn create_text_document(js_value: JsValue) -> TextDocumentItem {
     let js_text_document: JSTextDocument = serde_wasm_bindgen::from_value(js_value).unwrap();
 
-    TextDocumentItem {
-        uri: js_text_document.uri,
-        language_id: js_text_document.language_id,
-        version: js_text_document.version,
-        text: js_text_document.content,
+    js_text_document.into()
+}
+
+impl From<JSTextDocument> for TextDocumentItem {
+    fn from(val: JSTextDocument) -> Self {
+        TextDocumentItem {
+            uri: val.uri,
+            language_id: val.language_id,
+            version: val.version,
+            text: val.content,
+        }
     }
 }
 
 /// VS Code's `vscode-languageserver-textdocument` has a slightly different representation of a text document than lsp-types, as such for the serialization
 /// and deserialization of text documents we need to use a custom struct in between. Bit annoying but it works.
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct JSTextDocument {
     /// The text document's URI.

--- a/crates/csslsrs/tests/colors.rs
+++ b/crates/csslsrs/tests/colors.rs
@@ -310,7 +310,7 @@ fn assert_color_presentations(
     expected_presentations_texts: Vec<&str>,
 ) {
     let range = color.range;
-    let presentations = ls.get_color_presentations(color, range);
+    let presentations = ls.get_color_presentations(color);
 
     assert_eq!(
         presentations.len(),

--- a/crates/csslsrs/tests/colors.rs
+++ b/crates/csslsrs/tests/colors.rs
@@ -347,7 +347,7 @@ fn assert_color_symbols(
         text: text.to_string(),
     };
 
-    ls.store.upsert_document(document.clone());
+    ls.upsert_document(document.clone());
 
     let colors = ls.get_document_colors(document);
 

--- a/crates/csslsrs/tests/folding.rs
+++ b/crates/csslsrs/tests/folding.rs
@@ -436,7 +436,7 @@ fn assert_folding_ranges(text: &str, expected_ranges: Vec<FoldingRange>) {
         text.to_string(),
     );
 
-    ls.store.upsert_document(document.clone());
+    ls.upsert_document(document.clone());
 
     let mut folding_ranges = ls.get_folding_ranges(document);
 

--- a/crates/csslsrs/tests/hover.rs
+++ b/crates/csslsrs/tests/hover.rs
@@ -45,7 +45,7 @@ fn assert_hover(text_with_cursor: &str, expected_hover: Hover) {
         text.clone(),
     );
 
-    ls.store.upsert_document(document.clone());
+    ls.upsert_document(document.clone());
 
     let position = offset_to_position(&text, offset);
     let hover = ls.get_hover(document, position);

--- a/crates/weblsp/src/css.rs
+++ b/crates/weblsp/src/css.rs
@@ -1,13 +1,12 @@
 use crate::cast;
 use csslsrs::service::LanguageService;
-use csslsrs::service::LanguageServiceOptions;
 use lsp_server::{Connection, Message, Request, Response};
 use std::error::Error;
 
 /// Initialize our CSS Language Service (CSSlsrs).
 /// Used once at the start of the main loop, so the document store stays alive throughout the server's lifetime.
 pub fn init_language_service() -> LanguageService {
-    LanguageService::new(LanguageServiceOptions::default())
+    LanguageService::default()
 }
 
 /// Handle WEBlsp's CSS requests. This function will be called by the main loop when a CSS request is received,
@@ -68,7 +67,7 @@ fn get_text_document(
     text_document_identifier: lsp_types::TextDocumentIdentifier,
     language_service: &LanguageService,
 ) -> Result<lsp_types::TextDocumentItem, Box<dyn Error + Sync + Send>> {
-    let text_document = match language_service.store.get(&text_document_identifier.uri) {
+    let text_document = match language_service.get_document(&text_document_identifier.uri) {
         Some(doc) => doc,
         None => return Err(Box::from("Document not found")),
     };

--- a/crates/weblsp/src/css.rs
+++ b/crates/weblsp/src/css.rs
@@ -25,14 +25,11 @@ pub fn handle_request(
         }
         "textDocument/colorPresentation" => {
             let (id, params) = cast::<lsp_types::request::ColorPresentationRequest>(req)?;
-            let presentations = language_service.get_color_presentations(
-                lsp_types::ColorInformation {
+            let presentations =
+                language_service.get_color_presentations(lsp_types::ColorInformation {
                     color: params.color,
                     range: params.range,
-                },
-                // Erika se fout de ma gueule
-                params.range,
-            );
+                });
             send_result(
                 connection,
                 id,

--- a/crates/weblsp/src/notifications.rs
+++ b/crates/weblsp/src/notifications.rs
@@ -24,9 +24,7 @@ pub fn handle_notification(
                     eprintln!(
                         "textDocument/didOpen: adding CSS document to CSS Language Service store"
                     );
-                    css_language_service
-                        .store
-                        .upsert_document(params.text_document);
+                    css_language_service.upsert_document(params.text_document);
                 }
                 _ => {
                     eprintln!(
@@ -40,15 +38,13 @@ pub fn handle_notification(
             // We need to update the document in the store with the new content at each change.
             let params: DidChangeTextDocumentParams =
                 serde_json::from_value(notification.params).unwrap();
-            css_language_service
-                .store
-                .upsert_document(TextDocumentItem {
-                    uri: params.text_document.uri,
-                    language_id: "css".to_string(),
-                    version: params.text_document.version,
-                    // Since we only support full text sync, we can just take the first change.
-                    text: params.content_changes[0].text.clone(),
-                });
+            css_language_service.upsert_document(TextDocumentItem {
+                uri: params.text_document.uri,
+                language_id: "css".to_string(),
+                version: params.text_document.version,
+                // Since we only support full text sync, we can just take the first change.
+                text: params.content_changes[0].text.clone(),
+            });
         }
         _ => {
             eprintln!("unknown notification: {}", notification.method);

--- a/crates/weblsp/src/requests.rs
+++ b/crates/weblsp/src/requests.rs
@@ -41,7 +41,7 @@ fn get_language_id(
     let text_document_uri = lsp_types::Uri::from_str(text_document_identifier)
         .map_err(|_| "Invalid 'textDocument.uri' in request parameters")?;
 
-    let store_entry = match css_language_service.store.get(&text_document_uri) {
+    let store_entry = match css_language_service.get_document(&text_document_uri) {
         Some(doc) => doc,
         None => return Err(Box::from("Document not found")),
     };

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ build mode=default_mode:
 build-wasm mode=default_mode:
 	just fetch-data
 	echo "Building to WASM target..."
-	cargo build --target wasm32-unknown-unknown {{ if mode == "release" {"--release"} else if mode == "benchmark" {"--profile benchmark"} else {""} }} --features wasm
+	cargo build --package csslsrs --target wasm32-unknown-unknown {{ if mode == "release" {"--release"} else if mode == "benchmark" {"--profile benchmark"} else {""} }} --features wasm
 	wasm-bindgen ./target/wasm32-unknown-unknown/{{mode}}/csslsrs.wasm --out-dir ./packages/csslsrs/src/generated --target=experimental-nodejs-module {{ if mode == "release" { "" } else { "--keep-debug" } }}
 	{{ if mode == "release" { "wasm-opt -O4 ./packages/csslsrs/src/generated/csslsrs_bg.wasm -o ./packages/csslsrs/src/generated/csslsrs_bg.wasm" } else { "" } }}
 	pnpm -C ./packages/csslsrs install

--- a/packages/benchmark-wasm/benchmarks/colors.bench.ts
+++ b/packages/benchmark-wasm/benchmarks/colors.bench.ts
@@ -33,7 +33,7 @@ const color = (await ls.get_document_colors(textDocument))[0];
 
 describe("Document colors", async () => {
 	bench("CSSLSRS(WASM) - Document colors", async () => {
-		await ls.get_document_colors(textDocument);
+		await ls.get_document_colors(textDocument.uri);
 	});
 	if (!process.env.CODSPEED) {
 		bench("vscode-css-languageservice - Document colors", () => {

--- a/packages/benchmark-wasm/benchmarks/colors.bench.ts
+++ b/packages/benchmark-wasm/benchmarks/colors.bench.ts
@@ -1,4 +1,4 @@
-import { get_color_presentations, get_document_colors } from "csslsrs";
+import { LanguageService } from "csslsrs";
 import { getCSSLanguageService } from "vscode-css-languageservice";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { bench, describe } from "vitest";
@@ -23,11 +23,17 @@ h2 {
 `;
 
 const textDocument = TextDocument.create("file:///test.css", "css", 0, content);
-const color = (await get_document_colors(textDocument))[0];
+const ls = new LanguageService({
+	include_base_css_custom_data: true,
+});
+
+await ls.upsert_document(textDocument);
+
+const color = (await ls.get_document_colors(textDocument))[0];
 
 describe("Document colors", async () => {
 	bench("CSSLSRS(WASM) - Document colors", async () => {
-		await get_document_colors(textDocument);
+		await ls.get_document_colors(textDocument);
 	});
 	if (!process.env.CODSPEED) {
 		bench("vscode-css-languageservice - Document colors", () => {
@@ -38,8 +44,8 @@ describe("Document colors", async () => {
 });
 
 describe("Color Presentations", async () => {
-	bench("CSSLSRS(WASM) - Color Presentations", () => {
-		get_color_presentations(color, color.range);
+	bench("CSSLSRS(WASM) - Color Presentations", async () => {
+		await ls.get_color_presentations(color);
 	});
 
 	if (!process.env.CODSPEED) {

--- a/packages/benchmark-wasm/benchmarks/colors.bench.ts
+++ b/packages/benchmark-wasm/benchmarks/colors.bench.ts
@@ -27,13 +27,13 @@ const ls = new LanguageService({
 	include_base_css_custom_data: true,
 });
 
-await ls.upsert_document(textDocument);
+ls.upsertDocument(textDocument);
 
-const color = (await ls.get_document_colors(textDocument.uri))[0];
+const color = ls.getDocumentColors(textDocument.uri)[0];
 
 describe("Document colors", async () => {
-	bench("CSSLSRS(WASM) - Document colors", async () => {
-		await ls.get_document_colors(textDocument.uri);
+	bench("CSSLSRS(WASM) - Document colors", () => {
+		ls.getDocumentColors(textDocument.uri);
 	});
 	if (!process.env.CODSPEED) {
 		bench("vscode-css-languageservice - Document colors", () => {
@@ -44,8 +44,8 @@ describe("Document colors", async () => {
 });
 
 describe("Color Presentations", async () => {
-	bench("CSSLSRS(WASM) - Color Presentations", async () => {
-		await ls.get_color_presentations(color);
+	bench("CSSLSRS(WASM) - Color Presentations", () => {
+		ls.getColorPresentations(color);
 	});
 
 	if (!process.env.CODSPEED) {

--- a/packages/benchmark-wasm/benchmarks/colors.bench.ts
+++ b/packages/benchmark-wasm/benchmarks/colors.bench.ts
@@ -29,7 +29,7 @@ const ls = new LanguageService({
 
 await ls.upsert_document(textDocument);
 
-const color = (await ls.get_document_colors(textDocument))[0];
+const color = (await ls.get_document_colors(textDocument.uri))[0];
 
 describe("Document colors", async () => {
 	bench("CSSLSRS(WASM) - Document colors", async () => {

--- a/packages/benchmark-wasm/benchmarks/folding_ranges.bench.ts
+++ b/packages/benchmark-wasm/benchmarks/folding_ranges.bench.ts
@@ -44,11 +44,11 @@ const ls = new LanguageService({
 	include_base_css_custom_data: false,
 });
 
-ls.upsert_document(textDocument);
+ls.upsertDocument(textDocument);
 
 describe("Folding Ranges", async () => {
-	bench("CSSLSRS(WASM) - Folding Ranges", async () => {
-		await ls.get_folding_ranges(textDocument.uri);
+	bench("CSSLSRS(WASM) - Folding Ranges", () => {
+		ls.getFoldingRanges(textDocument.uri);
 	});
 	if (!process.env.CODSPEED) {
 		bench("vscode-css-languageservice - Folding Ranges", () => {

--- a/packages/benchmark-wasm/benchmarks/folding_ranges.bench.ts
+++ b/packages/benchmark-wasm/benchmarks/folding_ranges.bench.ts
@@ -1,4 +1,4 @@
-import { get_folding_ranges } from "csslsrs";
+import { LanguageService } from "csslsrs";
 import { getCSSLanguageService } from "vscode-css-languageservice";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { bench, describe } from "vitest";
@@ -40,15 +40,19 @@ h4 {
 `;
 
 const textDocument = TextDocument.create("file:///test.css", "css", 0, content);
+const ls = new LanguageService({
+	include_base_css_custom_data: true,
+});
+
+await ls.upsert_document(textDocument);
 
 describe("Folding Ranges", async () => {
 	bench("CSSLSRS(WASM) - Folding Ranges", async () => {
-		await get_folding_ranges(textDocument);
+		await ls.get_folding_ranges(textDocument);
 	});
 	if (!process.env.CODSPEED) {
 		bench("vscode-css-languageservice - Folding Ranges", () => {
-			const stylesheet = vscodeLanguageService.parseStylesheet(textDocument);
-			vscodeLanguageService.getFoldingRanges(textDocument, stylesheet);
+			vscodeLanguageService.getFoldingRanges(textDocument);
 		});
 	}
 });

--- a/packages/benchmark-wasm/benchmarks/folding_ranges.bench.ts
+++ b/packages/benchmark-wasm/benchmarks/folding_ranges.bench.ts
@@ -41,14 +41,14 @@ h4 {
 
 const textDocument = TextDocument.create("file:///test.css", "css", 0, content);
 const ls = new LanguageService({
-	include_base_css_custom_data: true,
+	include_base_css_custom_data: false,
 });
 
-await ls.upsert_document(textDocument);
+ls.upsert_document(textDocument);
 
 describe("Folding Ranges", async () => {
 	bench("CSSLSRS(WASM) - Folding Ranges", async () => {
-		await ls.get_folding_ranges(textDocument);
+		await ls.get_folding_ranges(textDocument.uri);
 	});
 	if (!process.env.CODSPEED) {
 		bench("vscode-css-languageservice - Folding Ranges", () => {

--- a/packages/benchmark-wasm/benchmarks/hover.bench.ts
+++ b/packages/benchmark-wasm/benchmarks/hover.bench.ts
@@ -1,11 +1,11 @@
-import { get_hover } from "../../csslsrs/dist/generated/csslsrs"
-import { getCSSLanguageService } from "vscode-css-languageservice"
-import { TextDocument } from "vscode-languageserver-textdocument"
-import { bench, describe } from "vitest"
+import { LanguageService } from "../../csslsrs/dist/index.js";
+import { getCSSLanguageService } from "vscode-css-languageservice";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { bench, describe } from "vitest";
 
 describe("Hover", async () => {
-  const vscodeLanguageService = getCSSLanguageService()
-  const content = `
+	const vscodeLanguageService = getCSSLanguageService();
+	const content = `
 body {
   background-color: #fff;
 }
@@ -21,26 +21,30 @@ h1.foo {
 h1 > span {
   color: linear-gradient(to right, red, #fff);
 }
-`
+`;
 
-  const textDocument = TextDocument.create(
-    "file:///test.css",
-    "css",
-    0,
-    content
-  )
+	const textDocument = TextDocument.create(
+		"file:///test.css",
+		"css",
+		0,
+		content
+	);
+	const ls = new LanguageService({
+		include_base_css_custom_data: true,
+	});
+	await ls.upsert_document(textDocument);
 
-  bench("CSSLSRS(WASM) - Hover", async () => {
-    await get_hover(textDocument, { line: 4, character: 3 })
-  })
-  if (!process.env.CODSPEED) {
-    bench("vscode-css-languageservice - Hover", () => {
-      const stylesheet = vscodeLanguageService.parseStylesheet(textDocument)
-      vscodeLanguageService.doHover(
-        textDocument,
-        { line: 4, character: 3 },
-        stylesheet
-      )
-    })
-  }
-})
+	bench("CSSLSRS(WASM) - Hover", async () => {
+		await ls.get_hover(textDocument, { line: 4, character: 3 });
+	});
+	if (!process.env.CODSPEED) {
+		bench("vscode-css-languageservice - Hover", () => {
+			const stylesheet = vscodeLanguageService.parseStylesheet(textDocument);
+			vscodeLanguageService.doHover(
+				textDocument,
+				{ line: 4, character: 3 },
+				stylesheet
+			);
+		});
+	}
+});

--- a/packages/benchmark-wasm/benchmarks/hover.bench.ts
+++ b/packages/benchmark-wasm/benchmarks/hover.bench.ts
@@ -35,14 +35,17 @@ h1 > span {
 	await ls.upsert_document(textDocument);
 
 	bench("CSSLSRS(WASM) - Hover", async () => {
-		await ls.get_hover(textDocument.uri, { line: 4, character: 3 });
+		await ls.get_hover(textDocument.uri, {
+			line: 14,
+			character: 3,
+		});
 	});
 	if (!process.env.CODSPEED) {
 		bench("vscode-css-languageservice - Hover", () => {
 			const stylesheet = vscodeLanguageService.parseStylesheet(textDocument);
 			vscodeLanguageService.doHover(
 				textDocument,
-				{ line: 4, character: 3 },
+				{ line: 14, character: 3 },
 				stylesheet
 			);
 		});

--- a/packages/benchmark-wasm/benchmarks/hover.bench.ts
+++ b/packages/benchmark-wasm/benchmarks/hover.bench.ts
@@ -35,7 +35,7 @@ h1 > span {
 	await ls.upsert_document(textDocument);
 
 	bench("CSSLSRS(WASM) - Hover", async () => {
-		await ls.get_hover(textDocument, { line: 4, character: 3 });
+		await ls.get_hover(textDocument.uri, { line: 4, character: 3 });
 	});
 	if (!process.env.CODSPEED) {
 		bench("vscode-css-languageservice - Hover", () => {

--- a/packages/benchmark-wasm/benchmarks/hover.bench.ts
+++ b/packages/benchmark-wasm/benchmarks/hover.bench.ts
@@ -32,10 +32,10 @@ h1 > span {
 	const ls = new LanguageService({
 		include_base_css_custom_data: true,
 	});
-	await ls.upsert_document(textDocument);
+	ls.upsertDocument(textDocument);
 
-	bench("CSSLSRS(WASM) - Hover", async () => {
-		await ls.get_hover(textDocument.uri, {
+	bench("CSSLSRS(WASM) - Hover", () => {
+		ls.getHover(textDocument.uri, {
 			line: 14,
 			character: 3,
 		});

--- a/packages/csslsrs/src/index.ts
+++ b/packages/csslsrs/src/index.ts
@@ -1,6 +1,1 @@
-export {
-  get_folding_ranges,
-  get_document_colors,
-  get_color_presentations,
-  get_hover,
-} from "./generated/csslsrs.js"
+export { WASMLanguageService as LanguageService } from "./generated/csslsrs.js";

--- a/packages/csslsrs/test/features/colors.test.ts
+++ b/packages/csslsrs/test/features/colors.test.ts
@@ -1,20 +1,29 @@
 import { describe, it } from "mocha";
 import { expect } from "chai";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import {
-	get_document_colors,
-	get_color_presentations,
-} from "../../dist/generated/csslsrs.js";
+import { LanguageService } from "../../dist";
 
 describe("Colors", () => {
-	it("Can return document colors", async () => {
-		const myDocument = TextDocument.create(
+	let ls: LanguageService;
+	let document: TextDocument;
+
+	before(() => {
+		ls = new LanguageService({
+			include_base_css_custom_data: true,
+		});
+
+		document = TextDocument.create(
 			"file:///test.css",
 			"css",
 			0,
 			"body {\n    color: red;\n    background-color: #fff;\n}\n"
 		);
-		const colors = await get_document_colors(myDocument);
+
+		ls.upsert_document(document);
+	});
+
+	it("Can return document colors", async () => {
+		const colors = await ls.get_document_colors(document);
 
 		expect(colors).to.deep.equal([
 			{
@@ -57,18 +66,10 @@ describe("Colors", () => {
 	});
 
 	it("Can return color presentations", async () => {
-		const myDocument = TextDocument.create(
-			"file:///test.css",
-			"css",
-			0,
-			"body {\n    color: red;\n    background-color: #fff;\n}\n"
-		);
-		const colors = await get_document_colors(myDocument);
-		const color = colors[0];
-		const colorPresentations = await get_color_presentations(
-			color,
-			color.range
-		);
+		const colors = await ls.get_document_colors(document);
+		const firstcolor = colors[0];
+
+		const colorPresentations = await ls.get_color_presentations(firstcolor);
 
 		expect(colorPresentations).not.to.be.empty;
 	});

--- a/packages/csslsrs/test/features/colors.test.ts
+++ b/packages/csslsrs/test/features/colors.test.ts
@@ -19,11 +19,11 @@ describe("Colors", () => {
 			"body {\n    color: red;\n    background-color: #fff;\n}\n"
 		);
 
-		ls.upsert_document(document);
+		ls.upsertDocument(document);
 	});
 
-	it("Can return document colors", async () => {
-		const colors = await ls.get_document_colors(document.uri);
+	it("Can return document colors", () => {
+		const colors = ls.getDocumentColors(document.uri);
 
 		expect(colors).to.deep.equal([
 			{
@@ -65,11 +65,11 @@ describe("Colors", () => {
 		]);
 	});
 
-	it("Can return color presentations", async () => {
-		const colors = await ls.get_document_colors(document.uri);
+	it("Can return color presentations", () => {
+		const colors = ls.getDocumentColors(document.uri);
 		const firstcolor = colors[0];
 
-		const colorPresentations = await ls.get_color_presentations(firstcolor);
+		const colorPresentations = ls.getColorPresentations(firstcolor);
 
 		expect(colorPresentations).not.to.be.empty;
 	});

--- a/packages/csslsrs/test/features/colors.test.ts
+++ b/packages/csslsrs/test/features/colors.test.ts
@@ -23,7 +23,7 @@ describe("Colors", () => {
 	});
 
 	it("Can return document colors", async () => {
-		const colors = await ls.get_document_colors(document);
+		const colors = await ls.get_document_colors(document.uri);
 
 		expect(colors).to.deep.equal([
 			{
@@ -66,7 +66,7 @@ describe("Colors", () => {
 	});
 
 	it("Can return color presentations", async () => {
-		const colors = await ls.get_document_colors(document);
+		const colors = await ls.get_document_colors(document.uri);
 		const firstcolor = colors[0];
 
 		const colorPresentations = await ls.get_color_presentations(firstcolor);

--- a/packages/csslsrs/test/features/folding.test.ts
+++ b/packages/csslsrs/test/features/folding.test.ts
@@ -1,19 +1,30 @@
 import { describe, it } from "mocha";
 import { expect } from "chai";
-import { get_folding_ranges } from "../../dist/index.js";
+import { LanguageService } from "../../dist/index.js";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import type { FoldingRange } from "vscode-languageserver-types";
 
 describe("Folding", () => {
-  it("Can return folding ranges", async () => {
-    const myDocument = TextDocument.create("file:///test.css", "css", 0, "body {\n    margin: 0;\n    padding: 0;\n}\n");
-    const foldingRanges = await get_folding_ranges(myDocument);
+	it("Can return folding ranges", async () => {
+		const myDocument = TextDocument.create(
+			"file:///test.css",
+			"css",
+			0,
+			"body {\n    margin: 0;\n    padding: 0;\n}\n"
+		);
+		// @ts-ignore
+		const ls = new LanguageService({
+			include_base_css_custom_data: true,
+		});
+		ls.upsert_document(myDocument);
 
-    expect(foldingRanges).to.deep.equal([
-      {
-        endLine: 3,
-        startLine: 0,
-      },
-    ] satisfies FoldingRange[]);
-  });
+		const foldingRanges = await ls.get_folding_ranges(myDocument);
+
+		expect(foldingRanges).to.deep.equal([
+			{
+				endLine: 3,
+				startLine: 0,
+			},
+		] satisfies FoldingRange[]);
+	});
 });

--- a/packages/csslsrs/test/features/folding.test.ts
+++ b/packages/csslsrs/test/features/folding.test.ts
@@ -5,7 +5,7 @@ import { TextDocument } from "vscode-languageserver-textdocument";
 import type { FoldingRange } from "vscode-languageserver-types";
 
 describe("Folding", () => {
-	it("Can return folding ranges", async () => {
+	it("Can return folding ranges", () => {
 		const myDocument = TextDocument.create(
 			"file:///test.css",
 			"css",
@@ -16,9 +16,9 @@ describe("Folding", () => {
 		const ls = new LanguageService({
 			include_base_css_custom_data: true,
 		});
-		ls.upsert_document(myDocument);
+		ls.upsertDocument(myDocument);
 
-		const foldingRanges = await ls.get_folding_ranges(myDocument.uri);
+		const foldingRanges = ls.getFoldingRanges(myDocument.uri);
 
 		expect(foldingRanges).to.deep.equal([
 			{

--- a/packages/csslsrs/test/features/folding.test.ts
+++ b/packages/csslsrs/test/features/folding.test.ts
@@ -18,7 +18,7 @@ describe("Folding", () => {
 		});
 		ls.upsert_document(myDocument);
 
-		const foldingRanges = await ls.get_folding_ranges(myDocument);
+		const foldingRanges = await ls.get_folding_ranges(myDocument.uri);
 
 		expect(foldingRanges).to.deep.equal([
 			{

--- a/packages/csslsrs/test/features/hover.test.ts
+++ b/packages/csslsrs/test/features/hover.test.ts
@@ -1,11 +1,18 @@
 import { describe, it } from "mocha";
 import { expect } from "chai";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { get_hover } from "../../../csslsrs/dist/index";
+import { LanguageService } from "../../../csslsrs/dist/index";
 
 describe("Hover", () => {
-	it("Can return hover", async () => {
-		const myDocument = TextDocument.create(
+	let ls: LanguageService;
+	let document: TextDocument;
+
+	before(() => {
+		ls = new LanguageService({
+			include_base_css_custom_data: true,
+		});
+
+		document = TextDocument.create(
 			"file:///test.css",
 			"css",
 			0,
@@ -13,7 +20,12 @@ describe("Hover", () => {
   background-color: #fff;
     }`
 		);
-		const hover = await get_hover(myDocument, { line: 0, character: 3 });
+
+		ls.upsert_document(document);
+	});
+
+	it("Can return hover", async () => {
+		const hover = await ls.get_hover(document, { line: 0, character: 3 });
 
 		expect(hover).to.deep.equal({
 			contents: {

--- a/packages/csslsrs/test/features/hover.test.ts
+++ b/packages/csslsrs/test/features/hover.test.ts
@@ -21,11 +21,11 @@ describe("Hover", () => {
     }`
 		);
 
-		ls.upsert_document(document);
+		ls.upsertDocument(document);
 	});
 
-	it("Can return hover", async () => {
-		const hover = await ls.get_hover(document.uri, { line: 0, character: 3 });
+	it("Can return hover", () => {
+		const hover = ls.getHover(document.uri, { line: 0, character: 3 });
 
 		expect(hover).to.deep.equal({
 			contents: {

--- a/packages/csslsrs/test/features/hover.test.ts
+++ b/packages/csslsrs/test/features/hover.test.ts
@@ -25,7 +25,7 @@ describe("Hover", () => {
 	});
 
 	it("Can return hover", async () => {
-		const hover = await ls.get_hover(document, { line: 0, character: 3 });
+		const hover = await ls.get_hover(document.uri, { line: 0, character: 3 });
 
 		expect(hover).to.deep.equal({
 			contents: {


### PR DESCRIPTION
## What does this change?
 
* `crates/csslsrs/src/service.rs`: Updated the `LanguageService` struct to make `store` and `options` fields private. Also updated `ls.store.upsert_document` calls accordingly in `crates/csslsrs/benches`.
* `crates/csslsrs/src/converters/*`: Remove `WideEncoding` references to handle `Utf16` and `Utf32` encodings directly 
* `crates/csslsrs/src/features/colors.rs`: Updated the `get_color_presentations` function to remove the dupplicate `range` parameter and updated WASM bindings.
* `crates/csslsrs/src/features/folding.rs`: Updated WASM bindings for `get_folding_ranges` to use the updated document handling logic.
* `crates/csslsrs/src/features/hover.rs`: Updated WASM bindings for `get_hover` to use the updated document handling logic.

## How is it tested?

Existing tests should still pass, after updating `LanguageService` usage.

## How is it documented?

N/A.